### PR TITLE
Enable -sse, -sse2 optimization to generate code optimized with SIMD.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ This is a JavaScript binding that exposes OpenCV library to the web. This projec
 2. Install emscripten 1.35.0. Other versions can be used as well, but currently, the patch is provided for only this version. You can obtain emscripten by using [Emscripten SDK](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html).
   
   ```
-  ./emsdk install sdk-1.35.0-64bit
-  ./emsdk activate sdk-1.35.0-64bit
+  ./emsdk install sdk-master-64bit --shallow
+  ./emsdk activate sdk-master-64bit
   ```
 3. Patch Emscripten and OpenCV
   
   ```
-  patch -p1 < PATH/TO/patch_emscripten_1_35_0.diff
+  patch -p1 < PATH/TO/patch_emscripten_master.diff
   patch -p1 < patch_opencv.diff
   ```
 4. Compile OpenCV and generate bindings by executing make.py script.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ This is a JavaScript binding that exposes OpenCV library to the web. This projec
   ./emsdk install sdk-1.35.0-64bit
   ./emsdk activate sdk-1.35.0-64bit
   ```
-3. Patch the Emscripten
+3. Patch Emscripten and OpenCV
   
   ```
   patch -p1 < PATH/TO/patch_emscripten_1_35_0.diff
+  patch -p1 < patch_opencv.diff
   ```
 4. Compile OpenCV and generate bindings by executing make.py script.
   

--- a/README.md
+++ b/README.md
@@ -11,16 +11,25 @@ This is a JavaScript binding that exposes OpenCV library to the web. This projec
 2. Install emscripten 1.35.0. Other versions can be used as well, but currently, the patch is provided for only this version. You can obtain emscripten by using [Emscripten SDK](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html).
   
   ```
+  ./emsdk update
   ./emsdk install sdk-master-64bit --shallow
   ./emsdk activate sdk-master-64bit
+  source ./emsdk_env.sh
   ```
-3. Patch Emscripten and OpenCV
+3. Patch Emscripten & Rebuild. Patch OpenCV
   
   ```
   patch -p1 < PATH/TO/patch_emscripten_master.diff
+  patch -p1 < PATH/TO/patch_fastcomp_master_GVN.diff
+  patch -p1 < PATH/TO/patch_fastcomp_master_SROA.diff
   patch -p1 < patch_opencv.diff
   ```
-4. Compile OpenCV and generate bindings by executing make.py script.
+4. Rebuild emscripten
+  ```
+  ./emsdk install sdk-master-64bit --shallow
+  ```
+
+5. Compile OpenCV and generate bindings by executing make.py script.
   
   ```
     python make.py

--- a/make.py
+++ b/make.py
@@ -30,7 +30,7 @@ import tools.shared as emscripten
 
 # TODO: -msse2, SIMD.js is complaint with SSE2
 
-emcc_args = '-O3 --llvm-lto 1 -s NO_EXIT_RUNTIME=1 -s ASSERTIONS=1 -s AGGRESSIVE_VARIABLE_ELIMINATION=0 -s NO_DYNAMIC_EXECUTION=0 --memory-init-file 0 -s NO_FILESYSTEM=0 -s NO_BROWSER=0'.split(' ')
+emcc_args = '-O3 -msse2 --llvm-lto 1 -s NO_EXIT_RUNTIME=1 -s ASSERTIONS=1 -s AGGRESSIVE_VARIABLE_ELIMINATION=0 -s NO_DYNAMIC_EXECUTION=0 --memory-init-file 0 -s NO_FILESYSTEM=0'.split(' ')
 #emcc_args += '-s ALLOW_MEMORY_GROWTH=1'  # resizable heap
 
 
@@ -129,8 +129,8 @@ try:
                      '-DBUILD_TESTS=OFF',
                      '-DBUILD_SHARED_LIBS=OFF',
                      '-DWITH_IPP=OFF',
-                     '-DENABLE_SSE=OFF',
-                     '-DENABLE_SSE2=OFF',
+                     '-DENABLE_SSE=ON',
+                     '-DENABLE_SSE2=ON',
                      '-DENABLE_SSE3=OFF',
                      '-DENABLE_SSE41=OFF',
                      '-DENABLE_SSE42=OFF',

--- a/patch_emscripten_1_35_0.diff
+++ b/patch_emscripten_1_35_0.diff
@@ -1,5 +1,5 @@
---- ./emscripten/1.35.0/system/include/emscripten/bind.h	2015-10-19 10:11:20.000000000 -0700
-+++ ./emscripten/1.35.0/system/include/emscripten/bind.h	2016-01-06 20:03:15.000000000 -0800
+--- ./emscripten/master/system/include/emscripten/bind.h	2015-10-19 10:11:20.000000000 -0700
++++ ./emscripten/master/system/include/emscripten/bind.h	2016-01-06 20:03:15.000000000 -0800
 @@ -50,7 +50,7 @@
                  TYPEID floatType,
                  const char* name,

--- a/patch_fastcomp_master_GVN.patch
+++ b/patch_fastcomp_master_GVN.patch
@@ -1,0 +1,19 @@
+--- ./clang//fastcomp/src/lib/Transforms/Scalar/GVN.cpp	2016-03-10 11:56:33.968255293 +0200
++++ ./clang//fastcomp/src/lib/Transforms/Scalar/GVN.cpp	2016-03-10 11:55:06.252253874 +0200
+@@ -1893,6 +1893,16 @@
+ 
+   // ... to a pointer that has been loaded from before...
+   MemDepResult Dep = MD->getDependency(L);
++
++  if (Dep.getInst()) {
++    if (Dep.getInst()->getType()->isVectorTy() ^ L->getType()->isVectorTy())
++      return false;
++    if (StoreInst *DepSI = dyn_cast<StoreInst>(Dep.getInst())) {
++      if (DepSI->getOperand(0)->getType()->isVectorTy() ^ L->getType()->isVectorTy())
++        return false;
++    }
++  }
++
+   const DataLayout &DL = L->getModule()->getDataLayout();
+ 
+   // If we have a clobber and target data is around, see if this is a clobber

--- a/patch_fastcomp_master_SROA.patch
+++ b/patch_fastcomp_master_SROA.patch
@@ -1,0 +1,13 @@
+--- ./clang//fastcomp/src/lib/Transforms/Scalar/SROA.cpp	2016-03-10 11:56:37.464255349 +0200
++++ ./clang//fastcomp/src/lib/Transforms/Scalar/SROA.cpp	2016-03-10 11:55:19.804254093 +0200
+@@ -3836,8 +3836,8 @@
+ 
+   bool IsIntegerPromotable = isIntegerWideningViable(P, SliceTy, DL);
+ 
+-  VectorType *VecTy =
+-      IsIntegerPromotable ? nullptr : isVectorPromotionViable(P, DL);
++  VectorType *VecTy = nullptr;
++
+   if (VecTy)
+     SliceTy = VecTy;
+ 

--- a/patch_opencv.diff
+++ b/patch_opencv.diff
@@ -1,0 +1,11 @@
+--- a/opencv/cmake/OpenCVCompilerOptions.cmake	2016-01-14 10:30:06.617458710 +0200
++++ b/opencv/cmake/OpenCVCompilerOptions.cmake	2016-01-14 12:20:50.449304819 +0200
+@@ -102,7 +102,7 @@
+     add_extra_compiler_option(-Werror)
+   endif()
+ 
+-  if(X86 AND NOT MINGW64 AND NOT X86_64 AND NOT APPLE)
++  if(X86 AND NOT MINGW64 AND NOT X86_64 AND NOT APPLE AND NOT EMSCRIPTEN)
+     add_extra_compiler_option(-march=i686)
+   endif()
+ 


### PR DESCRIPTION
This change contains a patch to clang to prevent it emitting large intermediary vector types that prevented the build with sse flags.

Enable -sse/-sse2 flags in config. Small changes to README file.

Some tests see performance improvements, some might not work because due to incomplete browser support.

To test it in chrome you can use _--js-flags="--harmony --harmony-simd"_.

Feel free to merge this in another branch if you feel it breaks things.